### PR TITLE
[WIP] Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,37 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 *.sw[pon]
-*.pyc
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt

--- a/subpy/stdlib.py
+++ b/subpy/stdlib.py
@@ -28,6 +28,7 @@ def standard_library():
                    (pack not in jokes):
                     yield pack
 
+# Python 3.x, todo, this has changed
 libraries = [
      'ihooks',
      'quopri',

--- a/subpy/tests/test_features.py
+++ b/subpy/tests/test_features.py
@@ -46,7 +46,7 @@ class TestFeatureDetect(unittest.TestCase):
         def fn():
             x = 3
             def closure():
-                print x
+                print(x)
 
         self.has(f.Closures, fn)
 
@@ -78,7 +78,7 @@ class TestFeatureDetect(unittest.TestCase):
     def test_varargs2(self):
 
         def fn():
-            map(id, *xs)
+            list(map(id, *xs))
 
         self.has(f.VarArgs, fn)
 
@@ -247,7 +247,7 @@ class TestFeatureDetect(unittest.TestCase):
     def test_exec(self):
 
         def fn():
-            exec 'foo' in {}
+            exec('foo', {})
 
         self.has(f.Exec, fn)
 
@@ -329,7 +329,7 @@ class TestFeatureDetect(unittest.TestCase):
         def fn():
             for a in range(25):
                 pass
-            for a in xrange(25):
+            for a in range(25):
                 pass
 
         self.not_has(f.CustomIterators, fn)
@@ -337,15 +337,15 @@ class TestFeatureDetect(unittest.TestCase):
     def test_printing(self):
 
         def fn():
-            print 'hello world'
+            print('hello world')
 
         self.has(f.Printing, fn)
 
     def test_metaclass(self):
 
         def fn():
-            class Foo(object):
-                __metaclass__ = Bar
+            class Foo(object, metaclass=Bar):
+                pass
 
         self.has(f.Metaclasses, fn)
 

--- a/subpy/tests/test_features.py
+++ b/subpy/tests/test_features.py
@@ -145,7 +145,7 @@ class TestFeatureDetect(unittest.TestCase):
 
         self.has(f.ChainComparison, fn)
 
-    def test_exceptiosn1(self):
+    def test_exceptions1(self):
 
         def fn():
             raise Exception

--- a/subpy/validate.py
+++ b/subpy/validate.py
@@ -5,7 +5,7 @@ import inspect
 from textwrap import dedent
 from collections import deque, defaultdict
 
-from features import *
+from .features import *
 
 FullPython = set([
     ImplicitCasts,
@@ -75,7 +75,7 @@ class PythonVisitor(ast.NodeVisitor):
             source = dedent(inspect.getsource(source))
         if isinstance(source, types.LambdaType):
             source = dedent(inspect.getsource(source))
-        elif isinstance(source, (str, unicode)):
+        elif isinstance(source, str):
             source = source
         else:
             raise NotImplementedError
@@ -96,7 +96,7 @@ class PythonVisitor(ast.NodeVisitor):
 
     def visit_comprehension(self, node):
         if node.ifs:
-            ifs = map(self.visit, node.ifs)
+            ifs = list(map(self.visit, node.ifs))
         target = self.visit(node.target)
         iter = self.visit(node.iter)
 
@@ -172,7 +172,7 @@ class PythonVisitor(ast.NodeVisitor):
         pass
 
     def visit_BoolOp(self, node):
-        operands = map(self.visit, node.values)
+        operands = list(map(self.visit, node.values))
         operator = node.op.__class__
 
         ## Check for implicit coercions between numeric types
@@ -187,8 +187,8 @@ class PythonVisitor(ast.NodeVisitor):
 
     def visit_Call(self, node):
         name = self.visit(node.func)
-        args = map(self.visit, node.args)
-        keywords = map(self.visit, node.keywords)
+        args = list(map(self.visit, node.args))
+        keywords = list(map(self.visit, node.keywords))
 
         if node.starargs:
             ## Check for variadic arguments
@@ -199,7 +199,7 @@ class PythonVisitor(ast.NodeVisitor):
 
         if node.keywords or node.kwargs:
             ## Check for keyword arguments
-            kwargs = map(self.visit, node.keywords)
+            kwargs = list(map(self.visit, node.keywords))
 
             if KeywordArgs not in self.features:
                 self.action(node, KeywordArgs)
@@ -210,7 +210,7 @@ class PythonVisitor(ast.NodeVisitor):
             self.action(node, Classes)
 
         if node.bases:
-            bases = map(self.visit, node.bases)
+            bases = list(map(self.visit, node.bases))
 
             ## Check for single inheritance
             if len(bases) >= 1 and Inheritance not in self.features:
@@ -221,7 +221,7 @@ class PythonVisitor(ast.NodeVisitor):
                 self.action(node, MInheritance)
 
         if node.decorator_list:
-            decorators = map(self.visit, node.decorator_list)
+            decorators = list(map(self.visit, node.decorator_list))
 
             ## Check for class decorators
             if decorators and ClassDecorators not in self.features:
@@ -229,7 +229,7 @@ class PythonVisitor(ast.NodeVisitor):
 
 
         self.scope.append(('class', node))
-        body = map(self.visit, node.body)
+        body = list(map(self.visit, node.body))
         self.scope.pop()
 
     def visit_Compare(self, node):
@@ -237,8 +237,8 @@ class PythonVisitor(ast.NodeVisitor):
         if len(node.comparators) > 1 and ChainComparison not in self.features:
             self.action(node, ChainComparison)
 
-        operands = map(self.visit, [node.left] + node.comparators)
-        operators = map(lambda op: op.__class__, node.ops)
+        operands = list(map(self.visit, [node.left] + node.comparators))
+        operators = [op.__class__ for op in node.ops]
 
     def visit_Continue(self, node):
         ## Check for continue
@@ -246,18 +246,18 @@ class PythonVisitor(ast.NodeVisitor):
             self.action(node, Continue)
 
     def visit_Delete(self, node):
-        target = map(self.visit, node.targets)
+        target = list(map(self.visit, node.targets))
         if DelVar not in self.features:
             self.action(node, DelVar)
 
     def visit_Dict(self, node):
-        keys = map(self.visit, node.keys)
-        values = map(self.visit, node.values)
+        keys = list(map(self.visit, node.keys))
+        values = list(map(self.visit, node.values))
 
     def visit_DictComp(self, node):
         key = self.visit(node.key)
         value = self.visit(node.value)
-        gens = map(self.visit, node.generators)
+        gens = list(map(self.visit, node.generators))
 
         ## Check for dictionary comprehensions
         if DictComp not in self.features:
@@ -267,7 +267,7 @@ class PythonVisitor(ast.NodeVisitor):
         pass
 
     def visit_ExtSlice(self, node):
-        map(self.visit, node.dims)
+        list(map(self.visit, node.dims))
 
     def visit_ExceptHandler(self, node):
 
@@ -275,7 +275,7 @@ class PythonVisitor(ast.NodeVisitor):
             name = node.name.id
         #if node.type:
             #type = node.type.id
-        body = map(self.visit, node.body)
+        body = list(map(self.visit, node.body))
 
         if Exceptions not in self.features:
             self.action(node, Exceptions)
@@ -297,8 +297,8 @@ class PythonVisitor(ast.NodeVisitor):
     def visit_For(self, node):
         target = self.visit(node.target)
         iter = self.visit(node.iter)
-        body = map(self.visit, node.body)
-        orelse = map(self.visit, node.orelse)
+        body = list(map(self.visit, node.body))
+        orelse = list(map(self.visit, node.orelse))
 
         ## Check for custom iterators
         if CustomIterators not in self.features:
@@ -319,7 +319,7 @@ class PythonVisitor(ast.NodeVisitor):
         self.check_arguments(node)
 
         if node.decorator_list:
-            decorators = map(self.visit, node.decorator_list)
+            decorators = list(map(self.visit, node.decorator_list))
 
             ## Check for class decorators
             if decorators and Decorators not in self.features:
@@ -345,7 +345,7 @@ class PythonVisitor(ast.NodeVisitor):
 
     def visit_GeneratorExp(self, node):
         self.visit(node.elt)
-        map(self.visit, node.generators)
+        list(map(self.visit, node.generators))
 
         ## Check for dictionary comprehensions
         if GeneratorExp not in self.features:
@@ -353,8 +353,8 @@ class PythonVisitor(ast.NodeVisitor):
 
     def visit_If(self, node):
         test = self.visit(node.test)
-        body = map(self.visit, node.body)
-        orelse = map(self.visit, node.orelse)
+        body = list(map(self.visit, node.body))
+        orelse = list(map(self.visit, node.orelse))
 
     def visit_IfExp(self, node):
         test = self.visit(node.test)
@@ -415,7 +415,7 @@ class PythonVisitor(ast.NodeVisitor):
         body = self.visit(node.body)
 
     def visit_List(self, node):
-        elts = map(self.visit, node.elts)
+        elts = list(map(self.visit, node.elts))
 
         ## Check for hetereogenous lists
         if node.elts and not HeteroList in self.features:
@@ -426,7 +426,7 @@ class PythonVisitor(ast.NodeVisitor):
 
     def visit_ListComp(self, node):
         elt = self.visit(node.elt)
-        gens = map(self.visit, node.generators)
+        gens = list(map(self.visit, node.generators))
 
         ## Check for list comprehensions
         if ListComp not in self.features:
@@ -439,7 +439,7 @@ class PythonVisitor(ast.NodeVisitor):
         pass
 
     def visit_Module(self, node):
-        body = map(self.visit, node.body)
+        body = list(map(self.visit, node.body))
 
     def visit_Pass(self, node):
         pass
@@ -452,7 +452,7 @@ class PythonVisitor(ast.NodeVisitor):
         if node.dest:
             dest = self.visit(node.dest)
 
-        values = map(self.visit, node.values)
+        values = list(map(self.visit, node.values))
 
     def visit_Raise(self, node):
         if node.type:
@@ -471,11 +471,11 @@ class PythonVisitor(ast.NodeVisitor):
             self.action(node, MultipleReturn)
 
     def visit_Set(self, node):
-        elts = map(self.visit, node.elts)
+        elts = list(map(self.visit, node.elts))
 
     def visit_SetComp(self, node):
         elt = self.visit(node.elt)
-        gens = map(self.visit, node.generators)
+        gens = list(map(self.visit, node.generators))
 
         ## Check for set comprehensions
         if SetComp not in self.features:
@@ -517,27 +517,27 @@ class PythonVisitor(ast.NodeVisitor):
             self.action(node, Ellipsi)
 
     def visit_TryExcept(self, node):
-        body = map(self.visit, node.body)
+        body = list(map(self.visit, node.body))
         if node.handlers:
-            handlers = map(self.visit, node.handlers)
+            handlers = list(map(self.visit, node.handlers))
 
         if node.orelse:
-            orelse = map(self.visit, node.orelse)
+            orelse = list(map(self.visit, node.orelse))
 
         ## Check for exceptions
         if Exceptions not in self.features:
             self.action(node, Exceptions)
 
     def visit_TryFinally(self, node):
-        body = map(self.visit, node.body)
-        finalbody = map(self.visit, node.finalbody)
+        body = list(map(self.visit, node.body))
+        finalbody = list(map(self.visit, node.finalbody))
 
         ## Check for exceptions
         if Exceptions not in self.features:
             self.action(node, Exceptions)
 
     def visit_Tuple(self, node):
-        return map(self.visit, node.elts)
+        return list(map(self.visit, node.elts))
 
     def visit_UnaryOp(self, node):
         operand = self.visit(node.operand)
@@ -545,9 +545,9 @@ class PythonVisitor(ast.NodeVisitor):
 
     def visit_While(self, node):
         test = self.visit(node.test)
-        body = map(self.visit, node.body)
+        body = list(map(self.visit, node.body))
         if node.orelse:
-            orelse = map(self.visit, node.orelse)
+            orelse = list(map(self.visit, node.orelse))
 
     def visit_With(self, node):
         ## Check for context managers
@@ -557,7 +557,7 @@ class PythonVisitor(ast.NodeVisitor):
         exp = self.visit(node.context_expr)
         if node.optional_vars:
             var = node.optional_vars and self.visit(node.optional_vars)
-        body = map(self.visit, node.body)
+        body = list(map(self.visit, node.body))
 
     def visit_Yield(self, node):
         ## Check for generators

--- a/subpy/validate.py
+++ b/subpy/validate.py
@@ -190,19 +190,25 @@ class PythonVisitor(ast.NodeVisitor):
         args = list(map(self.visit, node.args))
         keywords = list(map(self.visit, node.keywords))
 
-        if node.starargs:
+        # Python 2.x - 3.4
+        if hasattr(node,"starargs") and node.starargs:
             ## Check for variadic arguments
             starargs = self.visit(node.starargs)
 
             if VarArgs not in self.features:
                 self.action(node, VarArgs)
 
-        if node.keywords or node.kwargs:
+        if (hasattr(node,'keywords') and node.keywords) or \
+            (hasattr(node,'kwargs') and node.kwargs):
             ## Check for keyword arguments
             kwargs = list(map(self.visit, node.keywords))
 
             if KeywordArgs not in self.features:
                 self.action(node, KeywordArgs)
+
+        # Python 3.5+
+        # TODO
+
 
     def visit_ClassDef(self, node):
 


### PR DESCRIPTION
Hey, just wanted to create a WIP PR so that you know folks are using this library. I haven't fully integrated it into the candidate project, but it seems like, in its ideal state, it would be an incredibly useful library. 

Most of the failures I think have to do with the changed return values in the AST library, mostly around the Call node's children.

Failing tests (all apply to Python 3.5 unless noted):
 - [ ] Python 2.x, `test_metaclass`
 - [ ] test_varargs2
 - [ ] test_ternary
 - [ ] test_printing
 - [ ] test_multiple_return
 - [ ] test_metaclass
 - [ ] test_heterolist
 - [ ] test_exec
 - [ ] test_exceptions3
 - [ ] test_exceptions2
 - [ ] test_ellipses2
 - [ ] test_ellipses_1
 - [ ] test_continue
 - [ ] test_assertions
 - [ ] test_fullstdlib (this is because the stdlib has changed in Python 3, just need to update this list)
 - [ ] test_exceptions1
 - [ ] test_context_managers

Many of those tests fail with a "blah has no attribute blee", which would just mean some extra conditionals to check for which Python version we're working in. 